### PR TITLE
Add null safety check for apiChannelRef in HandshakeMailbox and ReceivingMailbox

### DIFF
--- a/Standalone/commonSE/src/main/kotlin/com/github/hoshikurama/ticketmanager/commonse/proxymailboxes/base/HandshakeMailbox.kt
+++ b/Standalone/commonSE/src/main/kotlin/com/github/hoshikurama/ticketmanager/commonse/proxymailboxes/base/HandshakeMailbox.kt
@@ -18,8 +18,10 @@ abstract class HandshakeMailbox<Input, Output> {
 
     init {
         TMCoroutine.Supervised.launch { // Note: Supervised good since new object made on each reload
-            for (incomingMSG in apiChannelRef) {
-                channel.send(decodeOutput(incomingMSG))
+            apiChannelRef?.let { channelRef ->
+                for (incomingMSG in channelRef) {
+                    channel.send(decodeOutput(incomingMSG))
+                }
             }
         }
     }

--- a/Standalone/commonSE/src/main/kotlin/com/github/hoshikurama/ticketmanager/commonse/proxymailboxes/base/ReceivingMailbox.kt
+++ b/Standalone/commonSE/src/main/kotlin/com/github/hoshikurama/ticketmanager/commonse/proxymailboxes/base/ReceivingMailbox.kt
@@ -19,8 +19,10 @@ abstract class ReceivingMailbox<T> {
 
     init {
         TMCoroutine.Supervised.launch {
-            for (incomingMSG in apiChannelRef) {
-                channel.send(decode(incomingMSG))
+            apiChannelRef?.let { channelRef ->
+                for (incomingMSG in channelRef) {
+                    channel.send(decode(incomingMSG))
+                }
             }
         }
     }


### PR DESCRIPTION
Was receiving the following errors in console:
01.09 15:12:26 [Server] WARN Exception in thread "DefaultDispatcher-worker-3" java.lang.NullPointerException: Cannot invoke "com.github.hoshikurama.ticketmanager.shaded.kotlinx.coroutines.channels.ReceiveChannel.iterator()" because the return value of "com.github.hoshikurama.ticketmanager.commonse.proxymailboxes.base.ReceivingMailbox.getApiChannelRef()" is null
01.09 15:12:26 [Server] WARN at TMSE-Paper-11.2.1.jar//com.github.hoshikurama.ticketmanager.commonse.proxymailboxes.base.ReceivingMailbox$1.invokeSuspend(ReceivingMailbox.kt:22)
01.09 15:12:26 [Server] WARN at TMSE-Paper-11.2.1.jar//com.github.hoshikurama.ticketmanager.commonse.proxymailboxes.base.ReceivingMailbox$1.invoke(ReceivingMailbox.kt)
01.09 15:12:26 [Server] WARN at TMSE-Paper-11.2.1.jar//com.github.hoshikurama.ticketmanager.commonse.proxymailboxes.base.ReceivingMailbox$1.invoke(ReceivingMailbox.kt)
01.09 15:12:26 [Server] WARN at TMCore-11.2.0.jar//com.github.hoshikurama.tmcoroutine.TMCoroutine$Supervised$launch$1.invokeSuspend(TMCoroutine.kt:31)
01.09 15:12:26 [Server] WARN at TMCore-11.2.0.jar//com.github.hoshikurama.ticketmanager.shaded.kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
01.09 15:12:26 [Server] WARN at TMCore-11.2.0.jar//com.github.hoshikurama.ticketmanager.shaded.kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
01.09 15:12:26 [Server] WARN at TMCore-11.2.0.jar//com.github.hoshikurama.ticketmanager.shaded.kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
01.09 15:12:26 [Server] WARN at TMCore-11.2.0.jar//com.github.hoshikurama.ticketmanager.shaded.kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:829)
01.09 15:12:26 [Server] WARN at TMCore-11.2.0.jar//com.github.hoshikurama.ticketmanager.shaded.kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
01.09 15:12:26 [Server] WARN at TMCore-11.2.0.jar//com.github.hoshikurama.ticketmanager.shaded.kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
01.09 15:12:26 [Server] WARN Suppressed: com.github.hoshikurama.ticketmanager.shaded.kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@3d7f8ee, Dispatchers.Default]